### PR TITLE
Groups and Users support. V2 Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Serilog sink that writes events to a SignalR Hub
 
-## Configuration from hub server application
+## Configuration from hub application
 
 From within the SignalR server application with a hub named MyHub:
 
@@ -13,7 +13,7 @@ var hubContext = GlobalHost.ConnectionManager.GetHubContext<MyHub>();
 
 Log.Logger = new LoggerConfiguration()
 .MinimumLevel.Verbose()
-.WriteTo.SignalRServer(hubContext,
+.WriteTo.SignalR(hubContext,
   Serilog.Events.LogEventLevel.Information,
   groupNames: new[] { "CustomGroup"}, // default is null
   userIds: new[] { "JaneD1234" }, // default is null
@@ -28,7 +28,7 @@ From any client application with a hub hosted at `http://localhost:8080` and a h
 ```csharp
 Log.Logger = new LoggerConfiguration()
 .MinimumLevel.Verbose()
-.WriteTo.SignalRHub("http://localhost:8080",
+.WriteTo.SignalRClient("http://localhost:8080",
   Serilog.Events.LogEventLevel.Information,
   hub: "MyHub" // default is LogHub
   groupNames: new[] { "CustomGroup"}, // default is null

--- a/README.md
+++ b/README.md
@@ -2,4 +2,66 @@
 
 [![Build status](https://ci.appveyor.com/api/projects/status/292m45fa26x5iyfs/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-signalr/branch/master)
 
-A Serilog sink that writes events to SignalR
+A Serilog sink that writes events to a SignalR Hub
+
+## Configuration from hub application
+
+From within the SignalR server application with a hub named MyHub:
+
+```csharp
+var hubContext = GlobalHost.ConnectionManager.GetHubContext<MyHub>();
+
+Log.Logger = new LoggerConfiguration()
+.MinimumLevel.Verbose()
+.WriteTo.SignalR(hubContext,
+  Serilog.Events.LogEventLevel.Information,
+  groupNames: new[] { "CustomGroup"}, // default is null
+  userIds: new[] { "JaneD1234" }, // default is null
+  excludedConnectionIds: new[] { "12345", "678910" }) // default is null
+.CreateLogger();
+```
+
+## Configuration from other clients
+
+From any client application with a hub hosted at `http://localhost:8080` and a hub implemented named `MyHub`:
+
+```csharp
+Log.Logger = new LoggerConfiguration()
+.MinimumLevel.Verbose()
+.WriteTo.SignalRClient("http://localhost:8080",
+  Serilog.Events.LogEventLevel.Information,
+  hub: "MyHub" // default is LogHub
+  groupNames: new[] { "CustomGroup"}, // default is null
+  userIds: new[] { "JaneD1234" }) // default is null
+.CreateLogger();
+```
+
+### SignalR Server
+Create a hub class with any name that ends in `Hub` or use the default name `LogHub`. Then create a method named `receiveLogEvent`, which is capable of accepting all data from the sink.
+```csharp
+public class MyHub : Hub
+{
+  public void receiveLogEvent(string[] groups, string[] userIds, Serilog.Sinks.SignalR.Data.LogEvent logEvent)
+  {
+    // send to all clients
+    Clients.All.sendLogEvent(logEvent);
+    // just the specified groups
+	Clients.Groups(groups).sendLogEvent(logEvent);
+    // just the specified users
+    Clients.Users(users).sendLogEvent(logEvent);
+  }
+}
+```
+
+## Receiving the log event
+Set up a SignalR client and subscribe to the `sendLogEvent` method.
+
+```csharp
+var connection = new HubConnection("http://localhost:8080");
+var hubProxy = connection.CreateHubProxy("MyHub");
+
+hubProxy.On<Serilog.Sinks.SignalR.Data.LogEvent>("sendLogEvent", (logEvent) =>
+{
+  Console.WriteLine(logEvent.RenderedMessage);
+});
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Serilog sink that writes events to a SignalR Hub
 
-## Configuration from hub application
+## Configuration from hub server application
 
 From within the SignalR server application with a hub named MyHub:
 
@@ -13,7 +13,7 @@ var hubContext = GlobalHost.ConnectionManager.GetHubContext<MyHub>();
 
 Log.Logger = new LoggerConfiguration()
 .MinimumLevel.Verbose()
-.WriteTo.SignalR(hubContext,
+.WriteTo.SignalRServer(hubContext,
   Serilog.Events.LogEventLevel.Information,
   groupNames: new[] { "CustomGroup"}, // default is null
   userIds: new[] { "JaneD1234" }, // default is null
@@ -28,7 +28,7 @@ From any client application with a hub hosted at `http://localhost:8080` and a h
 ```csharp
 Log.Logger = new LoggerConfiguration()
 .MinimumLevel.Verbose()
-.WriteTo.SignalRClient("http://localhost:8080",
+.WriteTo.SignalRHub("http://localhost:8080",
   Serilog.Events.LogEventLevel.Information,
   hub: "MyHub" // default is LogHub
   groupNames: new[] { "CustomGroup"}, // default is null

--- a/src/Serilog.Sinks.SignalR/LoggerConfigurationSignalRExtensions.cs
+++ b/src/Serilog.Sinks.SignalR/LoggerConfigurationSignalRExtensions.cs
@@ -26,7 +26,7 @@ namespace Serilog
     public static class LoggerConfigurationSignalRExtensions
     {
         /// <summary>
-        /// Adds a sink that writes log events as documents to a SignalR hub. 
+        /// Adds a sink that writes log events as documents to a SignalR server. 
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="context">The hub context.</param>
@@ -39,7 +39,7 @@ namespace Serilog
         /// <param name="excludedConnectionIds">Signalr connection ID's to exclude from broadcast.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration SignalR(
+        public static LoggerConfiguration SignalRServer(
             this LoggerSinkConfiguration loggerConfiguration,
             IHubContext context,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
@@ -73,7 +73,7 @@ namespace Serilog
         /// <param name="userIds">ID's of the Signalr Users you are broadcasting the log event to. Default is All Users.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration SignalRClient(
+        public static LoggerConfiguration SignalRHub(
             this LoggerSinkConfiguration loggerConfiguration,
             string url,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,

--- a/src/Serilog.Sinks.SignalR/LoggerConfigurationSignalRExtensions.cs
+++ b/src/Serilog.Sinks.SignalR/LoggerConfigurationSignalRExtensions.cs
@@ -34,6 +34,9 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="groupNames">Names of the Signalr groups you are broadcasting the log event to. Default is All Groups.</param>
+        /// <param name="userIds">ID's of the Signalr Users you are broadcasting the log event to. Default is All Users.</param>
+        /// <param name="excludedConnectionIds">Signalr connection ID's to exclude from broadcast.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration SignalR(
@@ -42,14 +45,51 @@ namespace Serilog
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchPostingLimit = SignalRSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            string[] groupNames = null,
+            string[] userIds = null,
+            string[] excludedConnectionIds = null)
         {
-            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
-            if (context == null) throw new ArgumentNullException("context");
+            if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             var defaultedPeriod = period ?? SignalRSink.DefaultPeriod;
             return loggerConfiguration.Sink(
-                new SignalRSink(context, batchPostingLimit, defaultedPeriod, formatProvider),
+                new SignalRSink(context, batchPostingLimit, defaultedPeriod, formatProvider, groupNames, userIds, excludedConnectionIds),
+                restrictedToMinimumLevel);
+        }
+
+        /// <summary>
+        /// Adds a sink that writes log events as documents to a SignalR hub. 
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="url">The url of the hub. http://localhost:8080.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="hub">The name of the Signalr hub class. Default is LogHub</param>
+        /// <param name="groupNames">Names of the Signalr groups you are broadcasting the log event to. Default is All Groups.</param>
+        /// <param name="userIds">ID's of the Signalr Users you are broadcasting the log event to. Default is All Users.</param>
+        /// <returns>Logger configuration, allowing configuration to continue.</returns>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+        public static LoggerConfiguration SignalRClient(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string url,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            int batchPostingLimit = SignalRSink.DefaultBatchPostingLimit,
+            TimeSpan? period = null,
+            IFormatProvider formatProvider = null,
+            string hub = "LogHub",
+            string[] groupNames = null,
+            string[] userIds = null)
+        {
+            if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
+            if (url == null) throw new ArgumentNullException(nameof(url));
+
+            var defaultedPeriod = period ?? SignalRSink.DefaultPeriod;
+            return loggerConfiguration.Sink(
+                new SignalRClientSink(url, batchPostingLimit, defaultedPeriod, formatProvider, hub, groupNames, userIds),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.SignalR/LoggerConfigurationSignalRExtensions.cs
+++ b/src/Serilog.Sinks.SignalR/LoggerConfigurationSignalRExtensions.cs
@@ -26,7 +26,7 @@ namespace Serilog
     public static class LoggerConfigurationSignalRExtensions
     {
         /// <summary>
-        /// Adds a sink that writes log events as documents to a SignalR server. 
+        /// Adds a sink that writes log events as documents to a SignalR hub. 
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="context">The hub context.</param>
@@ -39,7 +39,7 @@ namespace Serilog
         /// <param name="excludedConnectionIds">Signalr connection ID's to exclude from broadcast.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration SignalRServer(
+        public static LoggerConfiguration SignalR(
             this LoggerSinkConfiguration loggerConfiguration,
             IHubContext context,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
@@ -73,7 +73,7 @@ namespace Serilog
         /// <param name="userIds">ID's of the Signalr Users you are broadcasting the log event to. Default is All Users.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration SignalRHub(
+        public static LoggerConfiguration SignalRClient(
             this LoggerSinkConfiguration loggerConfiguration,
             string url,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,

--- a/src/Serilog.Sinks.SignalR/Serilog.Sinks.SignalR.csproj
+++ b/src/Serilog.Sinks.SignalR/Serilog.Sinks.SignalR.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Serilog</RootNamespace>
     <AssemblyName>Serilog.Sinks.SignalR</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,29 +42,29 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.SignalR.Core.2.1.0\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.SignalR.Client, Version=2.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.SignalR.Client.2.2.1\lib\net45\Microsoft.AspNet.SignalR.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin">
-      <HintPath>..\..\packages\Microsoft.Owin.2.0.2\lib\net45\Microsoft.Owin.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.SignalR.Core.2.2.1\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security">
-      <HintPath>..\..\packages\Microsoft.Owin.Security.2.0.2\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.3.0.1\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
-    <Reference Include="Owin">
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.2.3.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.PeriodicBatching.2.1.0\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -80,6 +81,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Sinks\SignalR\Data\LogEvent.cs" />
+    <Compile Include="Sinks\SignalR\SignalRClientSink.cs" />
     <Compile Include="Sinks\SignalR\SignalRSink.cs" />
     <Compile Include="Sinks\SignalR\SignalRPropertyFormatter.cs" />
   </ItemGroup>

--- a/src/Serilog.Sinks.SignalR/app.config
+++ b/src/Serilog.Sinks.SignalR/app.config
@@ -1,15 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.2.0" newVersion="2.0.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.2.0" newVersion="2.0.2.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
 </configuration>

--- a/src/Serilog.Sinks.SignalR/packages.config
+++ b/src/Serilog.Sinks.SignalR/packages.config
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.SignalR.Core" version="2.1.0" targetFramework="net45" />
-  <package id="Microsoft.Owin" version="2.0.2" targetFramework="net45" />
-  <package id="Microsoft.Owin.Security" version="2.0.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
-  <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="Serilog" version="1.4.204" targetFramework="net45" />
+  <package id="Microsoft.AspNet.SignalR.Client" version="2.2.1" targetFramework="net46" />
+  <package id="Microsoft.AspNet.SignalR.Core" version="2.2.1" targetFramework="net46" />
+  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net46" />
+  <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
+  <package id="Owin" version="1.0" targetFramework="net46" />
+  <package id="Serilog" version="2.3.0" targetFramework="net46" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
* added group name and excluded connection support
* updated to latest version of serilog and signalr
* added support for multiple groups and users
* added support for a proxy based sink
* new extension method for creating the client sink
* new sink which accepts the uri, hubname, groups and users args to create a client connection which enables logging from other applications.
* added usage documentation to the readme